### PR TITLE
Fix Wrong WSA Action with Reused InputMessages

### DIFF
--- a/src/zeep/wsa.py
+++ b/src/zeep/wsa.py
@@ -16,7 +16,7 @@ class WsAddressingPlugin(Plugin):
     def egress(self, envelope, http_headers, operation, binding_options):
         """Apply the ws-addressing headers to the given envelope."""
 
-        wsa_action = operation.input.abstract.wsa_action
+        wsa_action = operation.abstract.wsa_action
         if not wsa_action:
             wsa_action = operation.soapaction
 

--- a/src/zeep/wsdl/bindings/soap.py
+++ b/src/zeep/wsdl/bindings/soap.py
@@ -76,7 +76,7 @@ class SoapBinding(Binding):
             if not options:
                 options = client.service._binding_options
 
-            if operation_obj.abstract.input_message.wsa_action:
+            if operation_obj.abstract.wsa_action:
                 envelope, http_headers = wsa.WsAddressingPlugin().egress(
                     envelope, http_headers, operation_obj, options
                 )

--- a/src/zeep/wsdl/definitions.py
+++ b/src/zeep/wsdl/definitions.py
@@ -62,6 +62,7 @@ class AbstractOperation(object):
         output_message=None,
         fault_messages=None,
         parameter_order=None,
+        wsa_action=None,
     ):
         """Initialize the abstract operation.
 
@@ -80,6 +81,7 @@ class AbstractOperation(object):
         self.output_message = output_message
         self.fault_messages = fault_messages
         self.parameter_order = parameter_order
+        self.wsa_action = wsa_action
 
 
 class PortType(object):

--- a/src/zeep/wsdl/parse.py
+++ b/src/zeep/wsdl/parse.py
@@ -114,15 +114,15 @@ def parse_abstract_operation(wsdl, xmlelement):
 
         if tag_name == "input":
             kwargs["input_message"] = param_value
+            wsa_action = msg_node.get(etree.QName(NSMAP["wsam"], "Action"))
+            if not wsa_action:
+                wsa_action = msg_node.get(etree.QName(NSMAP["wsaw"], "Action"))
+            if wsa_action:
+                kwargs["wsa_action"] = wsa_action
         elif tag_name == "output":
             kwargs["output_message"] = param_value
         else:
             kwargs["fault_messages"][param_name] = param_value
-
-        wsa_action = msg_node.get(etree.QName(NSMAP["wsam"], "Action"))
-        if not wsa_action:
-            wsa_action = msg_node.get(etree.QName(NSMAP["wsaw"], "Action"))
-        param_value.wsa_action = wsa_action
 
     kwargs["name"] = name
     kwargs["parameter_order"] = xmlelement.get("parameterOrder")

--- a/tests/test_wsa.py
+++ b/tests/test_wsa.py
@@ -99,6 +99,110 @@ def test_require_wsa(recwarn, monkeypatch):
     assert_nodes_equal(expected, envelope)
 
 
+def test_duplicate_message_wsa(recwarn, monkeypatch):
+    monkeypatch.setattr(
+        uuid, "uuid4", lambda: uuid.UUID("ada686f9-5995-4088-bea4-239f694b2eaf")
+    )
+
+    wsdl_main = StringIO(
+        """
+        <?xml version="1.0"?>
+        <wsdl:definitions
+          xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          xmlns:tns="http://tests.python-zeep.org/xsd-main"
+          xmlns:sec="http://tests.python-zeep.org/wsdl-secondary"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+          xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+          xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+          targetNamespace="http://tests.python-zeep.org/xsd-main">
+          <wsdl:types>
+            <xsd:schema
+                targetNamespace="http://tests.python-zeep.org/xsd-main"
+                xmlns:tns="http://tests.python-zeep.org/xsd-main">
+              <xsd:element name="input" type="xsd:string"/>
+              <xsd:element name="input2" type="xsd:string"/>
+            </xsd:schema>
+          </wsdl:types>
+
+          <wsdl:message name="dummyRequest">
+            <wsdl:part name="response" element="tns:input"/>
+          </wsdl:message>
+          <wsdl:message name="dummyResponse">
+            <wsdl:part name="response" element="tns:input2"/>
+          </wsdl:message>
+
+          <wsdl:portType name="TestPortType">
+            <wsdl:operation name="TestOperation1">
+              <wsdl:input message="dummyRequest" wsaw:Action="urn:action1"/>
+              <wsdl:output message="dummyResponse" wsaw:Action="urn:dummyResponse"/>
+            </wsdl:operation>
+            <wsdl:operation name="TestOperation2">
+              <wsdl:input message="dummyRequest" wsaw:Action="urn:action2"/>
+              <wsdl:output message="dummyResponse" wsaw:Action="urn:dummyResponse"/>
+            </wsdl:operation>
+          </wsdl:portType>
+
+          <wsdl:binding name="TestBinding" type="tns:TestPortType">
+            <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+            <wsdl:operation name="TestOperation1">
+              <soap:operation soapAction=""/>
+              <wsdl:input>
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output>
+                <soap:body use="literal"/>
+              </wsdl:output>
+            </wsdl:operation>
+            <wsdl:operation name="TestOperation2">
+              <soap:operation soapAction=""/>
+              <wsdl:input>
+                <soap:body use="literal"/>
+              </wsdl:input>
+              <wsdl:output>
+                <soap:body use="literal"/>
+              </wsdl:output>
+            </wsdl:operation>
+          </wsdl:binding>
+          <wsdl:service name="TestService">
+            <wsdl:documentation>Test service</wsdl:documentation>
+            <wsdl:port name="TestPortType" binding="tns:TestBinding">
+              <soap:address location="http://tests.python-zeep.org/test"/>
+            </wsdl:port>
+          </wsdl:service>
+        </wsdl:definitions>
+    """.strip()
+    )
+
+    client = stub(plugins=[], wsse=None)
+
+    transport = DummyTransport()
+    client = Client(wsdl_main, transport=transport)
+    binding = client.wsdl.services.get("TestService").ports.get("TestPortType").binding
+
+    envelope, headers = binding._create(
+        "TestOperation1",
+        args=["foo"],
+        kwargs={},
+        client=client,
+        options={"address": "http://tests.python-zeep.org/test"},
+    )
+    expected = """
+        <soap-env:Envelope
+            xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap-env:Header  xmlns:wsa="http://www.w3.org/2005/08/addressing">
+            <wsa:Action>urn:action1</wsa:Action>
+            <wsa:MessageID>urn:uuid:ada686f9-5995-4088-bea4-239f694b2eaf</wsa:MessageID>
+            <wsa:To>http://tests.python-zeep.org/test</wsa:To>
+          </soap-env:Header>
+          <soap-env:Body>
+            <ns0:input xmlns:ns0="http://tests.python-zeep.org/xsd-main">foo</ns0:input>
+          </soap-env:Body>
+        </soap-env:Envelope>
+    """
+    assert_nodes_equal(expected, envelope)
+
+
 def test_force_wsa(recwarn, monkeypatch):
     monkeypatch.setattr(
         uuid, "uuid4", lambda: uuid.UUID("ada686f9-5995-4088-bea4-239f694b2eaf")


### PR DESCRIPTION
Allow AbstractOperations which share the same InputMessage to reference different WSA Actions as well. Previously, whenever two AbstractOperations referenced the same InputMessage, whichever was declared second would overwrite the wsa_action on the former. Here, we properly segregate the all message objects to whatever abstract operation they are associated with.